### PR TITLE
Apply filter with use.grch37 for ensemble URLs

### DIFF
--- a/R/Ensembl-utils.R
+++ b/R/Ensembl-utils.R
@@ -109,7 +109,14 @@ Ensembl_listMySQLCoreDirs <- function(mysql_url, release=NA, recache=FALSE)
         shortname0 <- strsplit(dataset, "_", fixed=TRUE)[[1L]][1L]
     }
     core_dir <- core_dirs[shortnames == shortname0]
-    core_dir <- grep("37$", core_dir, invert=!use.grch37, value=TRUE)
+    ## Starting with Ensembl 112, ftp.ensembl.org/pub/release-<version>/mysql/
+    ## contains two core subdirs for homo_sapiens:
+    ## homo_sapiens_core_<version>_38/ and homo_sapiens_core_<version>_37/.
+    ## We filter out the latter.
+    if (!use.grch37)
+        core_dir <- grep(
+            "^homo_sapiens_core_.*_37$", core_dir, invert=TRUE, value=TRUE
+        )
     if (length(core_dir) != 1L)
         stop("found 0 or more than 1 subdir for \"", dataset,
              "\" dataset at ", mysql_url)

--- a/R/Ensembl-utils.R
+++ b/R/Ensembl-utils.R
@@ -97,7 +97,8 @@ Ensembl_listMySQLCoreDirs <- function(mysql_url, release=NA, recache=FALSE)
     core_dirs[grep(pattern, core_dirs, fixed=TRUE)]
 }
 
-.Ensembl_getMySQLCoreDir <- function(dataset, mysql_url, release=NA)
+.Ensembl_getMySQLCoreDir <-
+    function(dataset, mysql_url, release=NA, use.grch37=FALSE)
 {
     core_dirs <- Ensembl_listMySQLCoreDirs(mysql_url, release=release)
     trimmed_core_dirs <- sub("_core_.*$", "", core_dirs)
@@ -108,6 +109,7 @@ Ensembl_listMySQLCoreDirs <- function(mysql_url, release=NA, recache=FALSE)
         shortname0 <- strsplit(dataset, "_", fixed=TRUE)[[1L]][1L]
     }
     core_dir <- core_dirs[shortnames == shortname0]
+    core_dir <- grep("37$", core_dir, invert=!use.grch37, value=TRUE)
     if (length(core_dir) != 1L)
         stop("found 0 or more than 1 subdir for \"", dataset,
              "\" dataset at ", mysql_url)
@@ -115,9 +117,12 @@ Ensembl_listMySQLCoreDirs <- function(mysql_url, release=NA, recache=FALSE)
 }
 
 ### Return URL of Ensemble Core DB (FTP access).
-.Ensembl_getMySQLCoreUrl <- function(dataset, mysql_url, release=NA)
+.Ensembl_getMySQLCoreUrl <-
+    function(dataset, mysql_url, release=NA, use.grch37=FALSE)
 {
-    core_dir <- .Ensembl_getMySQLCoreDir(dataset, mysql_url, release=release)
+    core_dir <- .Ensembl_getMySQLCoreDir(
+        dataset, mysql_url, release=release, use.grch37=use.grch37
+    )
     paste0(mysql_url, core_dir, "/")
 }
 
@@ -272,7 +277,9 @@ get_organism_from_Ensembl_Mart_dataset <- function(dataset, release=NA,
                                                    kingdom=NA)
 {
     mysql_url <- ftp_url_to_Ensembl_mysql(release, use.grch37, kingdom)
-    core_dir <- .Ensembl_getMySQLCoreDir(dataset, mysql_url, release=release)
+    core_dir <- .Ensembl_getMySQLCoreDir(
+        dataset, mysql_url, release=release, use.grch37=use.grch37
+    )
     organism <- sub("_core.*", "", core_dir)
     organism <- sub("_", " ", organism)
     substr(organism, 1L, 1L) <- toupper(substr(organism, 1L, 1L))
@@ -291,7 +298,9 @@ fetchChromLengthsFromEnsembl <- function(dataset, release=NA,
                                          extra_seqnames=NULL)
 {
     mysql_url <- ftp_url_to_Ensembl_mysql(release, use.grch37, kingdom)
-    core_url <- .Ensembl_getMySQLCoreUrl(dataset, mysql_url, release=release)
+    core_url <- .Ensembl_getMySQLCoreUrl(
+        dataset, mysql_url, release=release, use.grch37=use.grch37
+    )
     .Ensembl_fetchChromLengthsFromCoreUrl(core_url,
                                           extra_seqnames=extra_seqnames)
 }

--- a/man/txdbmaker-package.Rd
+++ b/man/txdbmaker-package.Rd
@@ -27,7 +27,7 @@
   \pkg{txdbmaker} package to be already installed.
 
   Alternatively this vignette should also be available online here:
-  \link{https://bioconductor.org/packages/release/bioc/vignettes/txdbmaker/inst/doc/txdbmaker.html}
+  \url{https://bioconductor.org/packages/release/bioc/vignettes/txdbmaker/inst/doc/txdbmaker.html}
 }
 
 \keyword{package}


### PR DESCRIPTION
It seems like some of the resources (`homo_sapiens`) from ensembl.org have a build number appended to the end of them: 

https://ftp.ensembl.org/pub/release-112/mysql/homo_sapiens_core_112_38/
https://ftp.ensembl.org/pub/release-112/mysql/homo_sapiens_core_112_37/

This is causing an error in OrganismDbi : 
https://bioconductor.org/checkResults/devel/bioc-LATEST/OrganismDbi/nebbiolo2-checksrc.html

```
odb <- makeOrganismDbFromBiomart(transcript_ids=transcript_ids)
#' Download and preprocess the 'transcripts' data frame ... OK
#' Download and preprocess the 'chrominfo' data frame ... FAILED! (=> skipped)
#' Error in S4Vectors:::extract_data_frame_rows(chrominfo, keep_idx) : 
#'   is.data.frame(x) is not TRUE
#' Calls: makeOrganismDbFromBiomart -> makeTxDbFromBiomart -> <Anonymous> -> stopifnot
#' Execution halted
```

This PR is a patch but perhaps it may also be due to errors in ensembl.org? I would imagine that grch37 files would only show up in https://ftp.ensembl.org/pub/grch37/ and not in the latest release `112`

Best,
Marcel
