### PR TITLE
Enable 'makeTxDbFromEnsembl()' to fill up genome version

### DIFF
--- a/R/Ensembl-utils.R
+++ b/R/Ensembl-utils.R
@@ -213,7 +213,8 @@ extract_chromlengths_from_seq_region <- function(seq_region,
         keep_me <- keep_me | (seq_region$seq_region_id %in% seq_region_ids)
     i1 <- which(keep_me)
     j1 <- c("seq_region_id", "name", "length",
-            "coord_system_name", "coord_system_rank")
+            "coord_system_name", "coord_system_rank",
+            "coord_system_version")
     ans <- seq_region[i1, j1, drop=FALSE]
 
     ## 2nd filtering: Keep only "toplevel" sequences that are not LRGs +
@@ -231,7 +232,8 @@ extract_chromlengths_from_seq_region <- function(seq_region,
     if (!is.null(seq_region_ids))
         keep_me <- keep_me | (ans$seq_region_id %in% seq_region_ids)
     i2 <- which(keep_me)
-    j2 <- c("seq_region_id", "name", "length", "coord_system_rank")
+    j2 <- c("seq_region_id", "name", "length", "coord_system_rank",
+            "coord_system_version")
     ans <- ans[i2, j2, drop=FALSE]
 
     ## Ordering: First by rank, then by name.
@@ -248,7 +250,7 @@ extract_chromlengths_from_seq_region <- function(seq_region,
     if (!is.null(seq_region_ids))
         keep_me <- keep_me | (ans$seq_region_id %in% seq_region_ids)
     i3 <- which(keep_me)
-    j3 <- c("seq_region_id", "name", "length")
+    j3 <- c("seq_region_id", "name", "length", "coord_system_version")
     ans <- ans[i3, j3, drop=FALSE]
 
     ## Final tidying.

--- a/R/makeTxDb.R
+++ b/R/makeTxDb.R
@@ -283,7 +283,7 @@
 .makeTxDb_normarg_chrominfo <- function(chrominfo)
 {
     .REQUIRED_COLS <- c("chrom", "length")
-    .OPTIONAL_COLS <- "is_circular"
+    .OPTIONAL_COLS <- c("is_circular", "genome")
     check_colnames(chrominfo, .REQUIRED_COLS, .OPTIONAL_COLS, "chrominfo")
     ## Check 'chrom'.
     if (!.is_character_or_factor(chrominfo$chrom)
@@ -305,6 +305,14 @@
         chrominfo$is_circular <- rep.int(NA, nrow(chrominfo))
     } else if (!is.logical(chrominfo$is_circular)) {
         stop(wmsg("'chrominfo$is_circular' must be a logical vector"))
+    }
+    ## Check 'genome'.
+    if (!has_col(chrominfo, "genome")) {
+        warning(wmsg("genome version information ",
+                     "is not available for this TxDb object"))
+        chrominfo$genome <- rep.int(NA, nrow(chrominfo))
+    } else if (!is.character(chrominfo$genome)) {
+        stop(wmsg("'chrominfo$genome' must be a character vector"))
     }
     chrominfo
 }
@@ -695,6 +703,17 @@ makeTxDb <- function(transcripts, splicings,
                           splicings_internal_cds_id,
                           splicings$cds_phase)
     .write_gene_table(conn, genes$gene_id, genes_internal_tx_id)
+    ## if input metadata has no specified genome and it is
+    ## available in 'chrominfo', try to fetch it from there
+    if (!"Genome" %in% metadata$name && !is.null(chrominfo$genome)) {
+        genome <- unique(chrominfo$genome)
+        if (length(genome) == 1L) { ## only if no conflicting genomes
+            if (is.null(metadata))
+                metadata <- data.frame(name="Genome", value=genome)
+            else if (identical(colnames(metadata), c("name", "value")))
+                metadata <- rbind(metadata, c("Genome", genome))
+        }
+    }
     .write_metadata_table(conn, metadata)  # must come last!
     GenomicFeatures:::TxDb(conn)
 }

--- a/R/makeTxDbFromEnsembl.R
+++ b/R/makeTxDbFromEnsembl.R
@@ -257,7 +257,8 @@
         length=chromlengths$length,
         is_circular=GenomeInfoDb:::make_circ_flags_from_circ_seqs(
                                                    chromlengths$name,
-                                                   circ_seqs)
+                                                   circ_seqs),
+        genome=chromlengths$coord_system_version
     )
     message("OK")
     chrominfo


### PR DESCRIPTION
Motivated by [this issue](https://github.com/rcastelo/gDNAx/issues/4#issuecomment-2468864641) opened in the gDNAx package, and related to this [other issue](https://github.com/Bioconductor/txdbmaker/issues/2) about adding genome version information to `TxDb` objects, this PR enables `makeTxDbFromEnsembl()` to fill up the genome version information available in the Ensembl database. Currently, this does not happen:

```
library(txdbmaker) ## current release 1.2.0 version

txdb <- makeTxDbFromEnsembl(organism="Mus musculus", circ_seqs="MT")
seqinfo(txdb)
Seqinfo object with 61 sequences (1 circular) from an unspecified genome:
  seqnames   seqlengths isCircular genome
  1           195154279      FALSE   <NA>
  2           181755017      FALSE   <NA>
  3           159745316      FALSE   <NA>
  4           156860686      FALSE   <NA>
  5           151758149      FALSE   <NA>
  ...               ...        ...    ...
  JH584300.1     182347      FALSE   <NA>
  JH584301.1     259875      FALSE   <NA>
  JH584302.1     155838      FALSE   <NA>
  JH584303.1     158099      FALSE   <NA>
  JH584304.1     114452      FALSE   <NA>
```
and AFAICS there is no workaround, because the function `makeTxDbFromEnsembl()` does not take a `metadata` argument as in `makeTxDbFromGFF()`. This PR allows `makeTxDbFromEnsembl()` to fill up the genome version:

```
library(txdbmaker) ## PR version

txdb <- makeTxDbFromEnsembl(organism="Mus musculus", circ_seqs="MT")
seqinfo(txdb)
Seqinfo object with 61 sequences (1 circular) from GRCm39 genome:
  seqnames   seqlengths isCircular genome
  1           195154279      FALSE GRCm39
  2           181755017      FALSE GRCm39
  3           159745316      FALSE GRCm39
  4           156860686      FALSE GRCm39
  5           151758149      FALSE GRCm39
  ...               ...        ...    ...
  JH584300.1     182347      FALSE GRCm39
  JH584301.1     259875      FALSE GRCm39
  JH584302.1     155838      FALSE GRCm39
  JH584303.1     158099      FALSE GRCm39
  JH584304.1     114452      FALSE GRCm39
```
The implementation adds the column `coord_system_version` from the `seq_region` table in the Ensembl database to a column called `genome` in the internal `chrominfo` `data.frame` object. This is passed to the `makeTxDb()` function, which uses that column to add that genome information as metadata when creating the `TxDb` object.