### PR TITLE
Add Taxonomy ID to TxDb returned by makeTxDbFromEnsembl()

### DIFF
--- a/R/makeTxDbFromEnsembl.R
+++ b/R/makeTxDbFromEnsembl.R
@@ -265,19 +265,28 @@
 }
 
 .gather_Ensembl_metadata <- function(organism, dbname, server,
-                                     tx_attrib=NULL)
+                                     tx_attrib=NULL, taxonomyId)
 {
     message("Gather the metadata ... ", appendLF=FALSE)
     release <- .dbname2release(dbname)
     full_dataset <- is.null(tx_attrib)
+
+    if(is.na(taxonomyId)){
+        taxonomyId <- GenomeInfoDb:::lookup_tax_id_by_organism(organism)
+    } else {
+        GenomeInfoDb:::check_tax_id(taxonomyId)
+    }
+
     metadata <- data.frame(name=c("Data source",
                                   "Organism",
+                                  "Taxonomy ID",
                                   "Ensembl release",
                                   "Ensembl database",
                                   "MySQL server",
                                   "Full dataset"),
                            value=c("Ensembl",
                                    organism,
+                                   taxonomyId,
                                    release,
                                    dbname,
                                    server,
@@ -300,7 +309,7 @@ makeTxDbFromEnsembl <- function(organism="Homo sapiens",
                                 circ_seqs=NULL,
                                 server="ensembldb.ensembl.org",
                                 username="anonymous", password=NULL,
-                                port=0L, tx_attrib=NULL)
+                                port=0L, tx_attrib=NULL, taxonomyId=NA)
 {
     S4Vectors:::load_package_gracefully("RMariaDB", "in order to ",
                                         "use makeTxDbFromEnsembl()")
@@ -339,7 +348,7 @@ makeTxDbFromEnsembl <- function(organism="Homo sapiens",
 
     chrominfo$seq_region_id <- NULL
 
-    metadata <- .gather_Ensembl_metadata(organism, dbname, server, tx_attrib)
+    metadata <- .gather_Ensembl_metadata(organism, dbname, server, tx_attrib, taxonomyId)
 
     message("Make the TxDb object ... ", appendLF=FALSE)
     txdb <- makeTxDb(transcripts, splicings,

--- a/man/makeTxDbFromEnsembl.Rd
+++ b/man/makeTxDbFromEnsembl.Rd
@@ -22,7 +22,7 @@ makeTxDbFromEnsembl(organism="Homo sapiens",
                     circ_seqs=NULL,
                     server="ensembldb.ensembl.org",
                     username="anonymous", password=NULL, port=0L,
-                    tx_attrib=NULL)
+                    tx_attrib=NULL, taxonomyId=NA)
 }
 
 \arguments{
@@ -58,6 +58,12 @@ makeTxDbFromEnsembl(organism="Homo sapiens",
   \item{tx_attrib}{
     If not \code{NULL}, only select transcripts with an attribute of
     the given code, a string, like \code{"gencode_basic"}.
+  }
+  \item{taxonomyId}{By default this value is NA and the dataset
+    selected will be used to look up the correct value for this.  But
+    you can use this argument to override that and supply your own
+    taxId here (which will be independently checked to make sure its a
+    real taxonomy id).  Normally you should never need to use this.
   }
 }
 


### PR DESCRIPTION
This PR adds the taxonomy ID to TxDb object returned by the `makeTxDbFromEnsembl` function.

Like other makeTxDbFrom functions, the default `taxonomyId` is set as `NA`.

The `lookup_tax_id_by_organism()` from the GenomeInfoDb package is used to retrieve taxonomy ID from `organism` by default, or `check_tax_id()` is used to check a taxonomic ID if given.

---

The TxDb object generated by the `makeTxDbFromEnsembl` function is missing the taxonomy ID. When I tried to use the `makeOrganismDbFromTxDb` function from the OrganismDbi package with the TxDb, will result in error. All other makeTxDbFrom functions adds taxonomy ID, and changes in the PR will probably be handy other than the case I provided about making a OrgDb.

https://github.com/Bioconductor/OrganismDbi/blob/a63751b6cc056aff02cfdedc1ef981d3317729a0/R/createOrganismPackage.R#L322-L323

